### PR TITLE
Fix method name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import (
 
 func main() {
   haikunator := haikunator.New(time.Now().UTC().UnixNano())
-  fmt.Println(haikunator.HaikuNate())
+  fmt.Println(haikunator.Haikunate())
 }
 
 ```


### PR DESCRIPTION
```
haikunator.HaikuNate undefined (type haikunator.Name has no field or method HaikuNate, but does have Haikunate)
```